### PR TITLE
Small modification to better support files in lower case and upper case on unix machine.

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -18,7 +18,7 @@ function expressMarkdown(options) {
 	dir = path.resolve(dir);
 
 	return function(req, res, next) {
-		var file = req.url.toString().toLowerCase();
+		var file = req.url.toString(); // the toLowerCase breaks when trying to access to files in upper case and lower case.
 
 		if (file.slice(-3) !== '.md' && file.slice(-9) !== '.markdown')
 			return next();


### PR DESCRIPTION
I removed the toLowerCase on the url because it was failing when trying to access to files mixing lowercase and uppercase or being completely in uppercase on linux.
If you wish to ignore the case on url side but take it into account on the filesystem side, it would require a bit longer modification.
