### PR TITLE
Default File when directory requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Usage
 	  // name of markdown variable passed in the context when rendering
 	  // optional
 	  // default 'markdown'
-	  variable: 'bar'
+	  variable: 'bar',
 
+	  // default markdown file to load if a directory is requested
+	  // optional
+	  // default 'readme.md'
+      defaultFile: 'index.md'
 	}));

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,57 +1,65 @@
 var fs = require('fs'),
-	path = require('path'),
-	url = require('url'),
-	markdown = require('marked');
+    path = require('path'),
+    url = require('url'),
+    markdown = require('marked');
 
 function expressMarkdown(options) {
-	if (!options)
-		throw new Error("Missing options argument");
+    if (!options)
+        throw new Error("Missing options argument");
 
-	var dir = options.directory,
-		view = options.view,
-		variable = options.variable || 'markdown';
+    var dir = options.directory,
+        view = options.view,
+        variable = options.variable || 'markdown',
+        defaultFile = options.defaultFile || 'readme.md';
 
-	if (!dir)
-		throw new Error('Missing "directory" value in options');
+    if (!dir)
+        throw new Error('Missing "directory" value in options');
 
-	// clean up path, remove '..'
-	dir = path.resolve(dir);
+    // clean up path, remove '..'
+    dir = path.resolve(dir);
 
-	return function(req, res, next) {
-		var file = req.url.toString(),
-			fileLower = file.toLowerCase();
+    return function(req, res, next) {
+        var file = req.url.toString().toLowerCase();
 
-		if (fileLower.slice(-3) !== '.md' && fileLower.slice(-9) !== '.markdown')
-			return next();
+        file = dir + '/' + url.parse(file).pathname;
 
-		file = dir + '/' + url.parse(file).pathname;
-		file = path.resolve(file);
+        // Check if file is a directory and if so append the default file
+        try {
+            if (fs.lstatSync(file).isDirectory()) {
+                file = file + (file.slice(-1) !== '/' ? '/' : '') + defaultFile;
+            }
+        } catch (e) {}
 
-		// make sure the final path is in our defined directory
-		if (file.substr(0, dir.length) !== dir)
-			return res.send(400);
+        if (file.slice(-3) !== '.md' && file.slice(-9) !== '.markdown')
+            return next();
 
-		fs.exists(file, function(exists) {
-			if (!exists)
-				return next();
+        file = path.resolve(file);
 
-			fs.readFile(file, 'utf8', function(err, data) {
-				var context = {};
-				if(err)
-					return next(err);
+        // make sure the final path is in our defined directory
+        if (file.substr(0, dir.length) !== dir)
+            return res.send(400);
 
-				data = markdown(data);
+        fs.exists(file, function(exists) {
+            if (!exists)
+                return next();
 
-				if (view) {
-					context[variable] = data;
-					res.render(view, context);
-				}
-				else {
-					res.send(data);
-				}
-			});
-		});
-	}
+            fs.readFile(file, 'utf8', function(err, data) {
+                var context = {};
+                if(err)
+                    return next(err);
+
+                data = markdown(data);
+
+                if (view) {
+                    context[variable] = data;
+                    res.render(view, context);
+                }
+                else {
+                    res.send(data);
+                }
+            });
+        });
+    }
 }
 
 module.exports = expressMarkdown;


### PR DESCRIPTION
Added the ability to allow for a directory URL to be requested. If
a directory is requested then a default markdown file is appended
to the file url.

If not specified the default file used is 'readme.md' however this
can be changed in the init options.